### PR TITLE
Fix issue with zero abundance detection

### DIFF
--- a/data_entry_helper.php
+++ b/data_entry_helper.php
@@ -6172,7 +6172,7 @@ if (errors$uniq.length>0) {
       // check for zero abundance records. First build a regexp that will match the attr IDs to check. Attrs can be
       // just set to true, which means any attr will do.
       if (is_array($zero_attrs))
-        $ids='['.implode('|',$zero_attrs).']';
+        $ids='('.implode('|',$zero_attrs).')';
       else
         $ids = '\d+';
       $zeroCount=0;


### PR DESCRIPTION
When zero_attributes is passed as an array to wrap_species_checklist_record_present, the code to generate the required regex for detecting the attributes uses [] when it should use () for alternates.
