### PR TITLE
Remove send_file_to_warehouse protection

### DIFF
--- a/helper_base.php
+++ b/helper_base.php
@@ -1328,7 +1328,7 @@ class helper_base extends helper_config {
    * @param string $service Path to the service URL used. Default is data/handle_media, but could be import/upload_csv.
    * @return string Error message, or true if successful.
    */
-  static function send_file_to_warehouse($path, $persist_auth=false, $readAuth = null, $service='data/handle_media') {
+  public static function send_file_to_warehouse($path, $persist_auth=false, $readAuth = null, $service='data/handle_media') {
     if ($readAuth==null) $readAuth=$_POST;
     $interim_image_folder = isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/';
     $interim_path = dirname(__FILE__).'/'.$interim_image_folder;

--- a/helper_base.php
+++ b/helper_base.php
@@ -1328,7 +1328,7 @@ class helper_base extends helper_config {
    * @param string $service Path to the service URL used. Default is data/handle_media, but could be import/upload_csv.
    * @return string Error message, or true if successful.
    */
-  protected static function send_file_to_warehouse($path, $persist_auth=false, $readAuth = null, $service='data/handle_media') {
+  static function send_file_to_warehouse($path, $persist_auth=false, $readAuth = null, $service='data/handle_media') {
     if ($readAuth==null) $readAuth=$_POST;
     $interim_image_folder = isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/';
     $interim_path = dirname(__FILE__).'/'.$interim_image_folder;


### PR DESCRIPTION
DP7 Indicia API module needs to send the photos to the warehouse and since it does not use _data_entry_helper::extract_media_data_ it needs to be able to upload the images to the warehouse. I can just copy the function code and use it in the new module, which works fine but I don't think I want to duplicate the code.