### PR TITLE
Fixes #76 - input contents not html-escaped

### DIFF
--- a/form_helper.php
+++ b/form_helper.php
@@ -423,7 +423,8 @@ $('#load-params').click(function() {
 
       // Current form settings will overwrite the default.
       if (isset($options['currentSettings']) && isset($options['currentSettings'][$control['fieldname']])) {
-        $ctrlOptions['default'] = $options['currentSettings'][$control['fieldname']];
+        $fieldSetting = $options['currentSettings'][$control['fieldname']];
+        $ctrlOptions['default'] = htmlspecialchars($fieldSetting, ENT_QUOTES, 'UTF-8');
       }
 
       $ctrlOptions['extraParams'] = array_merge($ctrlOptions['extraParams'], $options['readAuth']);


### PR DESCRIPTION
Runs all content through htmlspecialchars() before display
in input controls including <input> and <textarea>. Ensures content
is not interpreted as html by browser.