### PR TITLE
Requirement to move temporary image folder into files directory.

### DIFF
--- a/data_entry_helper.php
+++ b/data_entry_helper.php
@@ -1049,9 +1049,20 @@ JS;
    */
   public static function file_box($options) {
     global $indicia_templates;
-    // Upload directory defaults to client_helpers/upload, but can be overriden.
-    $interim_image_folder = isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/';
     $relpath = self::getRootFolder() . self::client_helper_path();
+    if(function_exists('conf_path')){
+    //image upload path if it is in Drupal.
+       $interim_image_folder = conf_path() . "/files/indicia/upload/";
+       $upload_folder = self::getRootFolder() . $interim_image_folder;
+    }else{
+    //For non-Drupal's image upload path.
+       $interim_image_folder = isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/';
+       $client_helper = self::client_helper_path();
+       $client_path =  'client_helpers/';
+       if($client_helper != 'client_helpers/')
+         $upload_folder = self::getRootFolder() . $client_path . $interim_image_folder;
+       else $upload_folder = self::getRootFolder() . $client_helper . $interim_image_folder;
+    }
     //If a subType option is supplied, it means we only want to load a particular media type, not just any old media associated with the sample
     if (!empty($options['subType']))
       self::$upload_file_types[$options['subType']]=self::$upload_file_types['image'];
@@ -1068,7 +1079,7 @@ JS;
       'autoupload' => true,
       'imageWidth' => 200,
       'uploadScript' => "$protocol://$_SERVER[HTTP_HOST]/" . self::getRootFolder() . self::relative_client_helper_path() . 'upload.php',
-      'destinationFolder' => $relpath . $interim_image_folder,
+      'destinationFolder' => $upload_folder,
       'finalImageFolder' => self::get_uploaded_image_folder(),
       'jsPath' => self::$js_path,
       'buttonTemplate' => $indicia_templates['button'],
@@ -3258,12 +3269,18 @@ RIJS;
       self::add_resource('plupload');
       // store some globals that we need later when creating uploaders
       $relpath = self::getRootFolder() . self::client_helper_path();
-      $interim_image_folder = isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/';
+      if(function_exists('conf_path')){
+        $interim_image_folder = conf_path() . "/files/indicia/upload/";
+        $upload_folder = self::getRootFolder() . $interim_image_folder;
+      }else{
+        $interim_image_folder = isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/';
+        $upload_folder = $relpath . $interim_image_folder;
+      }
       $js_path = self::$js_path;
       self::$javascript .= <<<JS
 indiciaData.uploadSettings = {
   uploadScript: '{$relpath}upload.php',
-  destinationFolder: '{$relpath}{$interim_image_folder}',
+  destinationFolder: '{$upload_folder}',
   jsPath: '$js_path'
 JS;
       $langStrings = array(

--- a/helper_base.php
+++ b/helper_base.php
@@ -313,6 +313,11 @@ class helper_base extends helper_config {
   public static $cache_folder = false;
 
   /**
+   * @var string Path to Indicia image upload folder. Defaults to client_helpers/upload.
+   */
+  public static $interim_image_folder = false;
+
+  /**
    * @var string Path to proxy script for calls to the warehouse (optional, allows the warehouse to sit behind a firewall only accessible
    * from the server).
    */
@@ -1353,17 +1358,9 @@ JS;
    */
   public static function send_file_to_warehouse($path, $persist_auth=false, $readAuth = null, $service='data/handle_media') {
     if ($readAuth==null) $readAuth=$_POST;
-    if(function_exists('conf_path')){
-    //image upload path if it is in Drupal.
-      $interim_image_folder = conf_path() . "/files/indicia/upload/";
-      $interim_path = getcwd() .'/' . $interim_image_folder;
-    }else{
-      //For non-Drupal's image upload path.
-      $interim_image_folder = isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/';
-      $client_helper = self::client_helper_path();
-      $interim_path = $client_helper . $interim_image_folder;
-    }
-    if (!file_exists($interim_path.$path))
+    $interim_image_folder = !empty(self::$interim_image_folder) ? self::$interim_image_folder : self::relative_client_helper_path() . 'upload/';
+    $interim_path = getcwd() . '/' . $interim_image_folder;
+	     if (!file_exists($interim_path.$path))
       return "The file $interim_path$path does not exist and cannot be uploaded to the Warehouse.";
     $serviceUrl = parent::$base_url."index.php/services/".$service;
     // This is used by the file box control which renames uploaded files using a guid system, so disable renaming on the server.
@@ -2485,12 +2482,7 @@ $.validator.messages.integer = $.validator.format(\"".lang::get('validation_inte
    * Internal function to ensure old image files are purged periodically.
    */
   protected static function _purgeImages() {
-    if(function_exists('conf_path')){
-      //image upload path if it is in Drupal.
-      $interimImageFolder = conf_path() . "/files/indicia/upload/";
-    }else{
-      $interimImageFolder = self::relative_client_helper_path() . (isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/');
-    }
+    $interimImageFolder = !empty(self::$interim_image_folder) ? self::$interim_image_folder : self::relative_client_helper_path() .  'upload/';
     self::purgeFiles(self::$cache_chance_purge, $interimImageFolder, self::$interim_image_expiry);
   }
 

--- a/helper_base.php
+++ b/helper_base.php
@@ -1353,8 +1353,16 @@ JS;
    */
   public static function send_file_to_warehouse($path, $persist_auth=false, $readAuth = null, $service='data/handle_media') {
     if ($readAuth==null) $readAuth=$_POST;
-    $interim_image_folder = isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/';
-    $interim_path = dirname(__FILE__).'/'.$interim_image_folder;
+    if(function_exists('conf_path')){
+    //image upload path if it is in Drupal.
+      $interim_image_folder = conf_path() . "/files/indicia/upload/";
+      $interim_path = getcwd() .'/' . $interim_image_folder;
+    }else{
+      //For non-Drupal's image upload path.
+      $interim_image_folder = isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/';
+      $client_helper = self::client_helper_path();
+      $interim_path = $client_helper . $interim_image_folder;
+    }
     if (!file_exists($interim_path.$path))
       return "The file $interim_path$path does not exist and cannot be uploaded to the Warehouse.";
     $serviceUrl = parent::$base_url."index.php/services/".$service;
@@ -2477,7 +2485,12 @@ $.validator.messages.integer = $.validator.format(\"".lang::get('validation_inte
    * Internal function to ensure old image files are purged periodically.
    */
   protected static function _purgeImages() {
-    $interimImageFolder = self::relative_client_helper_path() . (isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/');
+    if(function_exists('conf_path')){
+      //image upload path if it is in Drupal.
+      $interimImageFolder = conf_path() . "/files/indicia/upload/";
+    }else{
+      $interimImageFolder = self::relative_client_helper_path() . (isset(parent::$interim_image_folder) ? parent::$interim_image_folder : 'upload/');
+    }
     self::purgeFiles(self::$cache_chance_purge, $interimImageFolder, self::$interim_image_expiry);
   }
 

--- a/upload.php
+++ b/upload.php
@@ -12,7 +12,10 @@
   // Only output real errors. We don't want warnings to break the JSON
   error_reporting(E_ERROR);
 
-  // HTTP headers for no cache etc
+  // HTTP headers for no cache & CORS etc
+  header('Access-Control-Allow-Origin: *');
+  header('Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS');
+  header('Access-Control-Allow-Headers: Origin, Content-Type, X-Auth-Token'); 
   header('Content-type: text/html;');
   header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
   header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
@@ -27,9 +30,30 @@
   require('data_entry_helper.php');
 
   // Settings. 
-  // Note the interim image folder may not be in helper_config in which case use a default
-  $interim_image_folder = isset(helper_config::$interim_image_folder) ? helper_config::$interim_image_folder : 'upload/';
-  $targetDir = dirname(__FILE__) . '/' . $interim_image_folder;
+  // Get drupal & iForm module folders path
+  $rootpath=realpath('');
+  $rootpath=str_replace('\\','/',$rootpath);
+  $sites_pos=strpos($rootpath,'/sites');
+  $module_pos=strpos($rootpath,'/modules');
+  if($sites_pos && $module_pos){
+    $site_folder=substr($rootpath, 0, $sites_pos+6);
+    $url_folder=substr($rootpath, $sites_pos+7, $module_pos-$sites_pos-7);
+  }
+  if(isset($site_folder) && isset($url_folder) && $url_folder==='all'){
+    //if site uses the default folder.
+    $default_folder = $site_folder.'/default/files';
+    $targetDir = $site_folder . '/default/files/indicia/upload/';
+   }
+  else if (isset($url_folder) && $url_folder!=='all') {
+    //if site doesn't use default folder
+        $targetDir = $site_folder .'/'. $url_folder . '/files/indicia/upload/';
+    }
+  else{
+    //this is for Non-drupal sites.
+      // Note the interim image folder may not be in helper_config in which case use a default
+      $interim_image_folder = isset(helper_config::$interim_image_folder) ? helper_config::$interim_image_folder : 'upload/';
+      $targetDir = dirname(__FILE__) . '/' . $interim_image_folder;
+  }
   // Clenaup old .part upload files
   $cleanupTargetDir = true; 
   // Max .part file age in seconds


### PR DESCRIPTION
Upload.php file has now got provision to support CORS. This help to use upload feature on Pantheon cloud service.

The path of temporary image has been moved into sites/sitename/files/indicia or sites/default/files/indicia. This features will only useful for Drupal base site. 