### PR TITLE
Disabled use of OL2 restrictedExtent map property

### DIFF
--- a/prebuilt_forms/includes/map.php
+++ b/prebuilt_forms/includes/map.php
@@ -378,7 +378,9 @@ function iform_map_zoom_to_geom($geom, $name, $restrict=false) {
   $geomJson = json_encode($geoms);
   // Create code to restrict extent and zoom in if being asked to do so, will add to JS in a moment
   $restrictExtentCode = !$restrict ? '' : <<<SCRIPT
-  mapdiv.map.setOptions({restrictedExtent: bounds});
+  // Disabled used of OL2 restrictedExtent property because of interference with our 
+  // dynamic zooming: https://github.com/BiologicalRecordsCentre/iRecord/issues/655.
+  //mapdiv.map.setOptions({restrictedExtent: bounds});
   if (mapdiv.map.getZoomForExtent(bounds)>mapdiv.map.getZoom()) {
     mapdiv.map.zoomTo(mapdiv.map.getZoomForExtent(bounds));
   }


### PR DESCRIPTION
Setting this property interferred with the proper working of our
dynamic layer switching. See GitHub issue:
https://github.com/BiologicalRecordsCentre/iRecord/issues/655

Rather than remove the code I commented it out with a brief explanation and pointer to the issue. An alternative would be to ammed the PHP code which calls the function which sets up this JS, but this seems like the simplest and most explicit solution which facilitates us reverting if a solution is found in the future.