### PR TITLE
Remove restrict extent code on map

### DIFF
--- a/prebuilt_forms/dynamic_sample_occurrence.php
+++ b/prebuilt_forms/dynamic_sample_occurrence.php
@@ -686,7 +686,7 @@ class iform_dynamic_sample_occurrence extends iform_dynamic {
           $response = data_entry_helper::get_population_data(array(
             'table' => 'location',
             'extraParams' => $auth['read'] + array(
-                'query' => json_encode(array('in' => array('id'=>explode(',', $locationIDToLoad)))),
+                'query' => json_encode(array('in' => array('id' => explode(',', $locationIDToLoad)))),
                 'view' => 'detail'
               )
           ));
@@ -694,19 +694,19 @@ class iform_dynamic_sample_occurrence extends iform_dynamic {
           foreach ($response as $loc) {
             $geoms[] = $loc['boundary_geom'] ? $loc['boundary_geom'] : $loc['centroid_geom'];
           }
-          $geom = count($geoms)>1 ? 'GEOMETRYCOLLECTION(' . implode(',', $geoms) . ')' : $geoms[0];
-          $layerName = count($geoms)>1 ? lang::get('Boundaries') : lang::get('Boundary of {1}', $response[0]['name']);
-          iform_map_zoom_to_geom($geom, lang::get('{1} for the {2} group', $layerName, self::$group['title']), TRUE);
+          $geom = count($geoms) > 1 ? 'GEOMETRYCOLLECTION(' . implode(',', $geoms) . ')' : $geoms[0];
+          $layerName = count($geoms) > 1 ? lang::get('Boundaries') : lang::get('Boundary of {1}', $response[0]['name']);
+          iform_map_zoom_to_geom($geom, lang::get('{1} for the {2} group', $layerName, self::$group['title']));
           self::hide_other_boundaries($args);
         }
         elseif (!empty($filterDef->searchArea)) {
-          iform_map_zoom_to_geom($filterDef->searchArea, lang::get('Recording area for the {1} group', self::$group['title']), TRUE);
+          iform_map_zoom_to_geom($filterDef->searchArea, lang::get('Recording area for the {1} group', self::$group['title']));
           self::hide_other_boundaries($args);
         }
       }
-      if (!empty($filterDef->taxon_group_names) && !empty((array)$filterDef->taxon_group_names)) {
-        $args['taxon_filter'] = implode("\n", array_values((array)$filterDef->taxon_group_names));
-        $args['taxon_filter_field']='taxon_group';
+      if (!empty($filterDef->taxon_group_names) && !empty((array) $filterDef->taxon_group_names)) {
+        $args['taxon_filter'] = implode("\n", array_values((array) $filterDef->taxon_group_names));
+        $args['taxon_filter_field'] = 'taxon_group';
       }
       // @todo Consider other types of species filter, e.g. family or species list?
     }

--- a/prebuilt_forms/includes/map.php
+++ b/prebuilt_forms/includes/map.php
@@ -367,24 +367,19 @@ function iform_map_zoom_to_location($locationId, $readAuth) {
 
 /**
  * Draws and zooms the map into a geometry or list of geometries.
- * @param string|array $geom WKT string for the geom to zoom to, or an array of
- * WKT strings.
- * @param $name Layer name to add
- * @param bool $restrict Set true to limit the map to the area covering the geoms.
+ *
+ * @param string|array $geom
+ *   WKT string for the geom to zoom to, or an array of WKT strings.
+ * @param string $name
+ *   Layer name to add.
  */
-function iform_map_zoom_to_geom($geom, $name, $restrict=false) {
+function iform_map_zoom_to_geom($geom, $name) {
   $name = str_replace("'", "\\'", $name);
   $geoms = is_array($geom) ? $geom : [$geom];
   $geomJson = json_encode($geoms);
-  // Create code to restrict extent and zoom in if being asked to do so, will add to JS in a moment
-  $restrictExtentCode = !$restrict ? '' : <<<SCRIPT
-  mapdiv.map.setOptions({restrictedExtent: bounds});
-  if (mapdiv.map.getZoomForExtent(bounds)>mapdiv.map.getZoom()) {
-    mapdiv.map.zoomTo(mapdiv.map.getZoomForExtent(bounds));
-  }
-SCRIPT;
-  // Note, since the following moves the map, we want it to be the first mapInitialisationHook
-  data_entry_helper::$javascript .= <<<SCRIPT
+  // Note, since the following moves the map, we want it to be the first
+  // mapInitialisationHook.
+  data_entry_helper::$javascript .= <<<JS
 indiciaData.mapZoomPlanned = true;
 indiciaFns.zoomToBounds = function(mapdiv, bounds) {
   // Skip zoom to loaded bounds if already zoomed to a report output, remembering a position set in a cookie, or
@@ -435,9 +430,9 @@ mapInitialisationHooks.push(function(mapdiv) {
   indiciaData.initialBounds = bounds;
   mapdiv.map.addLayer(loclayer);
   indiciaFns.zoomToBounds(mapdiv, bounds);
-$restrictExtentCode
 });
-SCRIPT;
+
+JS;
 }
 
 /**


### PR DESCRIPTION
* Main reason is it breaks the new dynamic map layers - fixes
https://github.com/BiologicalRecordsCentre/iRecord/issues/655
* Also of dubious benefit.
* Tidied out unnecessary code relating to associated zoom in, as the
code always zooms to the geometries anyway.