### PR TITLE
Allow iform_user_ui_options to control georeferencer selection

### DIFF
--- a/form_helper.php
+++ b/form_helper.php
@@ -341,9 +341,24 @@ function hideMapsIfOverridden() {
       '<div class="alert alert-info">The base map layers are locked by the iform_user_ui_options module.</div>'
     );
   }
-}
+};
 
 hideMapsIfOverridden();
+
+/**
+ * Disallow georeferencer  selection if controlled by iform_user_ui_options.
+ */
+function disableGeoreferencerSelectionIfOverriden() {
+  // Disable georefrencer selection if override is supplied.
+  if (indiciaData.georeferencerOverride) {
+    $('#georefDriver').prop("disabled", true);
+    $('#ctrl-wrap-georefDriver').after(
+      '<div class="alert alert-info">The georeferencer is locked by the iform_user_ui_options module.</div>'
+    );
+  }
+};
+
+disableGeoreferencerSelectionIfOverriden();
 
 $('#form-category-picker').change(function(e) {
   var opts = '<option value="">$jsParams[langPleaseSelect]</option>';

--- a/form_helper.php
+++ b/form_helper.php
@@ -346,7 +346,7 @@ function hideMapsIfOverridden() {
 hideMapsIfOverridden();
 
 /**
- * Disallow georeferencer  selection if controlled by iform_user_ui_options.
+ * Disallow georeferencer selection if controlled by iform_user_ui_options.
  */
 function disableGeoreferencerSelectionIfOverriden() {
   // Disable georefrencer selection if override is supplied.


### PR DESCRIPTION
Issue https://github.com/BiologicalRecordsCentre/iRecord/issues/711 highlighted vulnerability of Indicia iForms to loss of georeferencing service. In this case the Nominatim service was unavailable for a short time. In the case of the loss of a georeferencing service, iRecord forms could individually be switched to another provider, e.g. in this case Google, but it would be better to have the option to globally override the selection of georeferencer on a per website basis rather than have to update all affected forms and then change them back again when service restored. This pull request - together with another on the iform_user_ui_options, enables us to do that.