### PR TITLE
Fixed bug with new statusFilters control

### DIFF
--- a/prebuilt_forms/includes/report_filters.php
+++ b/prebuilt_forms/includes/report_filters.php
@@ -858,7 +858,7 @@ function status_control ($readAuth, $options) {
   $ctl = new filter_quality();
   $r = '<div class="standalone-quality-filter">';
   $r .= $ctl->get_controls($readAuth, $options, array('status'));
-  $r .= '</dev>';
+  $r .= '</div>';
 
   report_helper::$onload_javascript .= <<<JS
     indiciaData.filter.def.quality = '!R';


### PR DESCRIPTION
@johnvanbreda there was a bug in the new statusFilters control that was causing it to interact with standardParams in an unintended way (and other problems besides).