### PR TITLE
Add check for specific occurrence against form filter

### DIFF
--- a/prebuilt_forms/dynamic_sample_occurrence.php
+++ b/prebuilt_forms/dynamic_sample_occurrence.php
@@ -700,6 +700,28 @@ TXT;
    * it available to a hook function which exists outside the form.
    */
   protected static function get_form_html($args, $auth, $attributes) {
+    if ($_GET['occurrence_id']!='' && $args['taxon_filter']!= '') {
+      // If an occurrence ID is passed in URL and the taxon
+      // filter argument is set on form, check that the taxon
+      // passes the filter and, if not, turn the filter off.
+      $record = data_entry_helper::get_population_data(array(
+        'table' => 'occurrence',
+        'extraParams' => $auth['read'] + array(
+            'id' => $_GET['occurrence_id'],
+            'view' => 'detail'
+          )
+      ));
+      $filtered_taxa = data_entry_helper::get_population_data(array(
+        'table' => 'taxa_search',
+        'extraParams' => $auth['read'] + array(
+            'taxa_taxon_list_id'=>$record[0]['taxa_taxon_list_id'],
+            $args['taxon_filter_field'] => json_encode($args['taxon_filter'])
+          )
+      ));
+      if (count($filtered_taxa) == 0) {
+        $args['taxon_filter']='';
+      }
+    }
     group_authorise_form($args, $auth['read']);
     // We always want an autocomplete formatter function for species lookups. The form implementation can
     // specify its own if required


### PR DESCRIPTION
Addresses part of issue 813. This addresses issue where non-moth records added via iRecord app cannot be edited using the iRecord form because a filter is set on that to only allow moth taxa. A check is added to dynamic_sample_occurrence.php to see if an occurrence ID is specified in URL. If it is and it does not pass the taxon filters specified on the form, it turns the filters off.