### PR TITLE
Added clustering to speciesmap control

### DIFF
--- a/data_entry_helper.php
+++ b/data_entry_helper.php
@@ -3296,9 +3296,7 @@ RIJS;
     $filterNameTypes = array('all','currentLanguage', 'preferred', 'excludeSynonyms');
     //make a copy of the options so that we can maipulate it
     $overrideOptions = $options;
-    //Set speciesInLabel option on indiciaData  
-    self::$indiciaData["speciesInLabel"] = $options['speciesInLabel'];
-
+ 
     //We are going to cycle through each of the name filter types
     //and save the parameters required for each type in an array so
     //that the Javascript can quickly access the required parameters

--- a/data_entry_helper.php
+++ b/data_entry_helper.php
@@ -3296,6 +3296,9 @@ RIJS;
     $filterNameTypes = array('all','currentLanguage', 'preferred', 'excludeSynonyms');
     //make a copy of the options so that we can maipulate it
     $overrideOptions = $options;
+    //Set speciesInLabel option on indiciaData  
+    self::$indiciaData["speciesInLabel"] = $options['speciesInLabel'];
+
     //We are going to cycle through each of the name filter types
     //and save the parameters required for each type in an array so
     //that the Javascript can quickly access the required parameters

--- a/prebuilt_forms/dynamic_sample_occurrence.php
+++ b/prebuilt_forms/dynamic_sample_occurrence.php
@@ -1651,6 +1651,11 @@ HTML;
     call_user_func(array(self::$called_class, 'build_grid_taxon_label_function'), $args, $options);
     if (self::$mode == self::MODE_CLONE)
       $species_ctrl_opts['useLoadedExistingRecords'] = true;
+
+    //Set speciesInLabel flag on indiciaData
+    $speciesInLabel = $options['speciesInLabel'] ? 'true' : 'false';
+    data_entry_helper::$javascript .= "\nindiciaData.speciesInLabel=".$speciesInLabel.";\n";
+
     return data_entry_helper::species_checklist($species_ctrl_opts);
   }
 

--- a/prebuilt_forms/dynamic_sample_occurrence.php
+++ b/prebuilt_forms/dynamic_sample_occurrence.php
@@ -1366,6 +1366,7 @@ HTML;
       $sampleCtrls = get_attribute_html($sampleAttrs, $args, array('extraParams' => $auth['read']), NULL, $attrOptions);
       $r .= "<div id=\"$options[id]-subsample-ctrls\" style=\"display: none\">$sampleCtrls</div>";
     }
+    $r .= "<div id=\"$options[id]-cluster\" style=\"display: none\"></div>";
     $r .= "<div id=\"$options[id]-container\" style=\"display: none\">" .
            // A dummy to capture feedback from the map.
            '<input type="hidden" id="imp-sref" />' .
@@ -1410,6 +1411,8 @@ HTML;
         'DeleteMessage' => lang::get("Please select the records on the map you wish to delete."),
         'ConfirmDeleteTitle' => lang::get("Confirm deletion of records"),
         'ConfirmDeleteText' => lang::get("Are you sure you wish to delete all the records at {OLD}?"),
+
+        'ClusterMessage' => lang::get("You selected a cluster of places on the map, pick one of them to work with."),
 
         'CancelLabel' => lang::get("Cancel"),
         'FinishLabel' => lang::get("Finish"),
@@ -1620,6 +1623,7 @@ HTML;
         'occurrenceSensitivity' => (isset($args['occurrence_sensitivity']) ? $args['occurrence_sensitivity'] : false),
         'occurrenceImages' => $args['occurrence_images'],
         'PHPtaxonLabel' => true,
+        'speciesInLabel' => false,
         'language' => iform_lang_iso_639_2(hostsite_get_user_field('language')), // used for termlists in attributes
         'speciesNameFilterMode' => self::getSpeciesNameFilterMode($args),
         'userControlsTaxonFilter' => isset($args['user_controls_taxon_filter']) ? $args['user_controls_taxon_filter'] : false,


### PR DESCRIPTION
In response to iRecord issue 813 - the part about being able to edit records from iRecord App which use sub-sample structure. Uses Open Layers 2 clustering strategy, as suggested, and if use selects a cluster for an update, move or delete operation, they are prompted to select the sub-sample within the cluster that they want to work with. Added new option to contol - @speciesInLabel - which, if set to true, changes the way sub-samples are labelled in map to include name of first species in label. This works well in situations, as for App, where sub-samples each have a single record. There is a corresponding pull request in media.