### PR TITLE
Added @singleRecordSubsamples to speciesmap control

### DIFF
--- a/prebuilt_forms/dynamic_sample_occurrence.php
+++ b/prebuilt_forms/dynamic_sample_occurrence.php
@@ -1410,6 +1410,8 @@ HTML;
 
   /* Set up the control JS and also return the existing data subsample blocks */
   protected static function get_control_speciesmap_controls($auth, $args, $options){
+    $defaults = array('singleRecordSubsamples' => false);
+    $options = array_merge($defaults, $options);
     $langStrings = array('AddLabel' => lang::get("Add records to map"),
         'AddMessage' => lang::get("Please click on the map where you would like to add your records. Zoom the map in for greater precision."),
         'AddDataMessage' => lang::get("Please enter all the species records for this position into the grid below. When you have finished, click the Finish button to return to the map where you may choose another grid reference to enter data for."),


### PR DESCRIPTION
Default is false. When set to true the control will not allow
more than one record per sub-sample. Originally required to use
this control for records added to the iRecord App General Survey.