### PR TITLE
Iss 931

### DIFF
--- a/ElasticsearchReportHelper.php
+++ b/ElasticsearchReportHelper.php
@@ -568,6 +568,7 @@ JS;
       'includeFiltersForSharingCodes' => [],
       'useSharingPrefix' => TRUE,
       'label' => 'Records to access',
+      'notices' => '[]'
     ], $options);
 
     $optionArr = [];
@@ -657,7 +658,32 @@ JS;
       'class' => 'permissions-filter',
     ];
 
-    return data_entry_helper::select($controlOptions);
+    $dropdown = data_entry_helper::select($controlOptions);
+    $html = <<<HTML
+<div>
+  $dropdown 
+  <div id="permission-filters-notice"></div>
+</div>
+
+HTML;
+
+  helper_base::$indiciaData['esPermissionFilterNotices'] = json_encode($options['notices']);
+  helper_base::$late_javascript .= <<<JS
+function permissionFilterChanged() {
+  var jsonFilterNotices = JSON.parse(indiciaData.esPermissionFilterNotices);
+  $('#permission-filters-notice').html('');
+  Object.keys(jsonFilterNotices).forEach(function(key) {
+    if ($('#es-permissions-filter option:selected').text().indexOf(key) === 0) {
+      $('#permission-filters-notice').html(jsonFilterNotices[key]);
+    }
+  });
+}
+$('#es-permissions-filter').on('change', permissionFilterChanged);
+permissionFilterChanged();
+
+JS;
+
+    return $html;
   }
 
   /**

--- a/ElasticsearchReportHelper.php
+++ b/ElasticsearchReportHelper.php
@@ -563,6 +563,10 @@ JS;
   public static function permissionFilters(array $options) {
     require_once 'prebuilt_forms/includes/report_filters.php';
 
+    $wrapperOptions = array_merge([
+      'id' => "es-permissions-filter-wrapper",
+    ], $options);
+
     $options = array_merge([
       'id' => "es-permissions-filter",
       'includeFiltersForGroups' => FALSE,
@@ -668,23 +672,8 @@ JS;
 
 HTML;
 
-  helper_base::$indiciaData['esPermissionFilterNotices'] = json_encode($options['notices']);
-  helper_base::$late_javascript .= <<<JS
-function permissionFilterChanged() {
-  var jsonFilterNotices = JSON.parse(indiciaData.esPermissionFilterNotices);
-  $('#permission-filters-notice').html('');
-  Object.keys(jsonFilterNotices).forEach(function(key) {
-    if ($('#es-permissions-filter option:selected').text().indexOf(key) === 0) {
-      $('#permission-filters-notice').html(jsonFilterNotices[key]);
-    }
-  });
-}
-$('#es-permissions-filter').on('change', permissionFilterChanged);
-permissionFilterChanged();
-
-JS;
-
-    return $html;
+    $dataOptions = helper_base::getOptionsForJs($options, ['notices'], TRUE);
+    return self::getControlContainer('permissionFilters', $wrapperOptions, $dataOptions, $html);
   }
 
   /**

--- a/ElasticsearchReportHelper.php
+++ b/ElasticsearchReportHelper.php
@@ -568,7 +568,7 @@ JS;
       'includeFiltersForSharingCodes' => [],
       'useSharingPrefix' => TRUE,
       'label' => 'Records to access',
-      'notices' => '[]'
+      'notices' => '[]',
     ], $options);
 
     $optionArr = [];

--- a/helper_base.php
+++ b/helper_base.php
@@ -916,6 +916,7 @@ class helper_base {
             self::$js_path . 'indicia.datacomponents/jquery.idc.templatedOutput.js',
             self::$js_path . 'indicia.datacomponents/jquery.idc.verificationButtons.js',
             self::$js_path . 'indicia.datacomponents/jquery.idc.filterSummary.js',
+            self::$js_path . 'indicia.datacomponents/jquery.idc.permissionFilters.js',
             'https://unpkg.com/@ungap/url-search-params',
           ],
         ],


### PR DESCRIPTION
Adds a new option - @notices - to ES permissionFilters control which allows a notice to be displayed conditional on the starting text of a permissions filter title. Example:
```
[permissionFilters]
@notices=<!--{
  "LERC download - ": "<p><b>For LERC downloads, you must abide by the <a href='https://www.brc.ac.uk/irecord/whatever'>LERC Terms and Conditions</a>.</b></p>"
}-->
```
The text is shown directly under the drop-down.