### PR TITLE
ES download filter labelling and filter format labelling

### DIFF
--- a/ElasticsearchReportHelper.php
+++ b/ElasticsearchReportHelper.php
@@ -380,9 +380,8 @@ class ElasticsearchReportHelper {
     // a select control that will be used to indicate the selected columns template.
     if (!empty($options['columnsTemplate']) && is_array($options['columnsTemplate'])) {
       $availableColTypes = array(
-        "default" => lang::get("Standard download format"),
-        "easy-download" => lang::get("Backward-compatible format"),
-        "mapmate" => lang::get("Mapmate-compatible format"),
+        "easy-download" => lang::get("Standard download format"),
+        "mapmate" => lang::get("Simple download format"),
       );
       $optionArr = array();
       foreach ($options['columnsTemplate'] as $colType) {
@@ -667,8 +666,12 @@ JS;
    */
   public static function surveyFilter(array $options) {
 
-    $controlOptions = [
+    $options = array_merge([
       'label' => lang::get('Limit to survey'),
+    ], $options);
+
+    $controlOptions = [
+      'label' => $options['label'],
       'fieldname' => 'es-survey-filter',
       'class' => 'es-filter-param survey-filter',
       'attributes' => array (
@@ -748,7 +751,7 @@ JS;
     }
 
     // Add in permission filters.
-    // Find allowed values onle.
+    // Find allowed values only.
     $sharingCodes = array_intersect(
       $options['includeFiltersForSharingCodes'],
       ['R', 'V', 'D', 'M', 'P']

--- a/prebuilt_forms/includes/report_filters.php
+++ b/prebuilt_forms/includes/report_filters.php
@@ -652,7 +652,7 @@ class filter_quality extends FilterBase {
         'R4' => lang::get('Not accepted as reviewer unable to verify records only'),
         'DR' => lang::get('Queried or not accepted records'),
       ];
-      if ($options['elasticsearch']) { 
+      if ($options['elasticsearch']) {
         // Elasticsearch doesn't currently support recorder trust.
         unset($qualityOptions['T']);
       }

--- a/prebuilt_forms/includes/report_filters.php
+++ b/prebuilt_forms/includes/report_filters.php
@@ -652,12 +652,16 @@ class filter_quality extends FilterBase {
         'R4' => lang::get('Not accepted as reviewer unable to verify records only'),
         'DR' => lang::get('Queried or not accepted records'),
       ];
-      if ($options['elasticsearch']) {
+      if ($options['elasticsearch']) { 
         // Elasticsearch doesn't currently support recorder trust.
         unset($qualityOptions['T']);
       }
-      $r .= data_entry_helper::select([
+      $options = array_merge([
         'label' => lang::get('Records to include'),
+      ], $options);
+
+      $r .= data_entry_helper::select([
+        'label' => $options['label'],
         'fieldname' => 'quality',
         'id' => 'quality-filter',
         'lookupValues' => $qualityOptions,


### PR DESCRIPTION
Removed the 'standard' format (which was really just our early
ES download format) from dropdown and renamed the previous
'backward compatible easy download' format as 'Standard ...' in
download format dropdwon. Renamed the MapMate format as
'Simple ...' in dropdown. Added label attribute for the
[statusFilter] and [surveyFilter] controls. Will update the docs.