### PR TITLE
Dynamic sample occurrence no longer loads training samples which don't match user's training setting

### DIFF
--- a/prebuilt_forms/dynamic_sample_occurrence.php
+++ b/prebuilt_forms/dynamic_sample_occurrence.php
@@ -926,6 +926,24 @@ TXT;
    * Override get_form_html to add extra functionality.
    */
   protected static function get_form_html($args, $auth, $attributes) {
+    if (function_exists('hostsite_get_user_field')  &&
+        (!empty($_GET['sample_id']) || !empty($_GET['occurrence_id']))) {
+      $trainingSample = 0;
+      if (!empty(data_entry_helper::$entity_to_load['sample:training']) &&
+          data_entry_helper::$entity_to_load['sample:training'] == 't') {
+        $trainingSample = 1;
+      }
+      if (hostsite_get_user_field('training') == 1 &&
+          $trainingSample == 0) {
+        return lang::get('<div>The sample cannot be displayed because your account is in training mode,
+        but the sample being loaded is not a training sample.</div>');
+      }
+      if (hostsite_get_user_field('training') == 0 &&
+          $trainingSample == 1) {
+        return lang::get('<div>The sample cannot be displayed because your account is not in training mode,
+        and the sample being loaded is a training sample.</div>');
+      }
+    }
     self::addNewSampleFromExistingSampleEntityToLoadRemover($args);
     group_authorise_form($args, $auth['read']);
     // We always want an autocomplete formatter function for species lookups.

--- a/prebuilt_forms/dynamic_sample_occurrence.php
+++ b/prebuilt_forms/dynamic_sample_occurrence.php
@@ -926,23 +926,9 @@ TXT;
    * Override get_form_html to add extra functionality.
    */
   protected static function get_form_html($args, $auth, $attributes) {
-    if (function_exists('hostsite_get_user_field')  &&
-        (!empty($_GET['sample_id']) || !empty($_GET['occurrence_id']))) {
-      $trainingSample = 0;
-      if (!empty(data_entry_helper::$entity_to_load['sample:training']) &&
-          data_entry_helper::$entity_to_load['sample:training'] == 't') {
-        $trainingSample = 1;
-      }
-      if (hostsite_get_user_field('training') == 1 &&
-          $trainingSample == 0) {
-        return lang::get('<div>The sample cannot be displayed because your account is in training mode,
-        but the sample being loaded is not a training sample.</div>');
-      }
-      if (hostsite_get_user_field('training') == 0 &&
-          $trainingSample == 1) {
-        return lang::get('<div>The sample cannot be displayed because your account is not in training mode,
-        and the sample being loaded is a training sample.</div>');
-      }
+    $trainingModeInconsistencyMessage = self::getTrainingModeInconsistencyMessage();
+    if (!empty($trainingModeInconsistencyMessage)) {
+      return $trainingModeInconsistencyMessage;
     }
     self::addNewSampleFromExistingSampleEntityToLoadRemover($args);
     group_authorise_form($args, $auth['read']);
@@ -1037,6 +1023,38 @@ TXT;
         'Use the "Save and publish" button to publish them when you are ready for them to be released.'));
     }
     return $r;
+  }
+
+  /**
+   * Disallow loading of samples which don't match the user's training setting.
+   *
+   * Do not allow samples to be loaded which do not match the user's
+   * account training mode setting (otherwise saving the sample
+   * will switch the training setting on the sample, unbeknown to the user)
+   *
+   * @return string
+   *   HTML for the control.
+   */
+  private static function getTrainingModeInconsistencyMessage() {
+    if (function_exists('hostsite_get_user_field')  &&
+        (!empty($_GET['sample_id']) || !empty($_GET['occurrence_id']))) {
+      $trainingSample = 0;
+      if (!empty(data_entry_helper::$entity_to_load['sample:training']) &&
+          data_entry_helper::$entity_to_load['sample:training'] == 't') {
+        $trainingSample = 1;
+      }
+      if (hostsite_get_user_field('training') == 1 &&
+          $trainingSample == 0) {
+        return lang::get('<div>The sample cannot be displayed because your account is in training mode,
+          but the sample being loaded is not a training sample.</div>');
+      }
+      if (hostsite_get_user_field('training') == 0 &&
+          $trainingSample == 1) {
+        return lang::get('<div>The sample cannot be displayed because your account is not in training mode,
+        and the sample being loaded is a training sample.</div>');
+      }
+    }
+    return '';
   }
 
   /**


### PR DESCRIPTION
Related to the pull request I just created for the Warehouse.

The problem at the moment  is if a sample is loaded which doesn't match the user's training setting, it will switch the sample training flag upon saving without the user realising.
(in practice this should be minimised as the report to access data entry page should be training flag sensitive, however there are concerns with this happening regularly on EBMS in the current state of the website)
