### PR TITLE
Fix problem where EBMS site was often reporting to users memory exhausted

### DIFF
--- a/prebuilt_forms/sectioned_transects_edit_transect.php
+++ b/prebuilt_forms/sectioned_transects_edit_transect.php
@@ -848,6 +848,7 @@ $('#delete-transect').click(deleteSurvey);
         $users[$user->id()] = $user->getDisplayName();
       }
     }
+    \Drupal::service('entity.memory_cache')->deleteAll();
     return $users;
   }
 


### PR DESCRIPTION
This is a simple addition, but am pull requesting in case there is any reason not to clear cache in this way here.
This is one of the pages I have used to assist with this
https://www.drupal.org/project/drupal/issues/3354201

Note I already put live on EBMS, as the problem was very severe for users